### PR TITLE
fix: add Google Cloud setup for end2end tests in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,17 @@ jobs:
           docker --version
           docker info
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Run end-to-end tests
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: go test -v ./tests/end2end/...
 
   release:


### PR DESCRIPTION
This PR adds the missing Google Cloud authentication and setup steps to the release pipeline's end-to-end test job, matching the configuration in `ci.yml`.

## Changes
- Added Google Cloud authentication step using `google-github-actions/auth@v2`
- Added Cloud SDK setup step using `google-github-actions/setup-gcloud@v2`
- Added `GCP_PROJECT_ID` environment variable to the end-to-end test run

This ensures that end-to-end tests requiring Google Cloud services (like GCSM) can run successfully in the release pipeline.