### PR TITLE
fix: replace .TagName with .Tag in GoReleaser release header template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,10 +56,10 @@ release:
     name: sstart
   mode: replace
   header: |
-    ## {{ .TagName }}
+    ## {{ .Tag }}
     {{ if .ReleaseNotes }}
     {{ .ReleaseNotes }}
     {{ else }}
-    Release {{ .TagName }}
+    Release {{ .Tag }}
     {{ end }}
 


### PR DESCRIPTION
## Problem
The release workflow was failing with the error:
```
error=scm releases: failed to publish artifacts: template: failed to apply "## {{ .TagName }}\n{{ if .ReleaseNotes }}\n{{ .ReleaseNotes }}\n{{ else }}\nRelease {{ .TagName }}\n{{ end }}\n": map has no entry for key "TagName"
```

## Solution
GoReleaser uses `{{ .Tag }}` instead of `{{ .TagName }}` for the tag name in templates. This PR replaces all instances of `.TagName` with `.Tag` in the release header template.

## Changes
- Updated `.goreleaser.yml` release header template to use `{{ .Tag }}` instead of `{{ .TagName }}`

This should fix the release workflow when creating new releases.