### PR TITLE
Add OpenBao support with end-to-end tests

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -288,9 +288,9 @@ If the secret value is plain text (not JSON), it will be mapped to a single envi
 
 For example, if the provider ID is `aws-prod`, the secret will be loaded to `AWS_PROD_SECRET`.
 
-### HashiCorp Vault (`vault`)
+### HashiCorp Vault / OpenBao (`vault`)
 
-Retrieves secrets from HashiCorp Vault. Supports both KV v1 and KV v2 secret engines.
+Retrieves secrets from HashiCorp Vault or OpenBao. Supports both KV v1 and KV v2 secret engines. OpenBao is a community-driven fork of HashiCorp Vault that maintains API compatibility, so the same `vault` provider works with both systems.
 
 **Configuration:**
 - `path` (required): The path to the secret in Vault
@@ -318,6 +318,24 @@ providers:
 
 **KV v1 and v2 Support:**
 The provider automatically detects and supports both KV v1 and KV v2 secret engines. For KV v2, the data is automatically extracted from the `data` key.
+
+**OpenBao Support:**
+OpenBao is a community-driven, open-source fork of HashiCorp Vault that maintains full API compatibility. You can use the same `vault` provider configuration to connect to OpenBao instances. Simply point the `address` field to your OpenBao server URL:
+
+```yaml
+providers:
+  - kind: vault
+    id: openbao-prod
+    address: https://openbao.example.com:8200
+    mount: secret
+    path: myapp/production
+    token: your-openbao-token
+    keys:
+      API_KEY: ==
+      DATABASE_URL: ==
+```
+
+The provider uses the same HashiCorp Vault API client, which is compatible with OpenBao's API. All features, including KV v1/v2 support, work identically with both Vault and OpenBao.
 
 ### Bitwarden (`bitwarden`)
 

--- a/tests/end2end/openbao_test.go
+++ b/tests/end2end/openbao_test.go
@@ -1,0 +1,180 @@
+package end2end
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dirathea/sstart/internal/config"
+	_ "github.com/dirathea/sstart/internal/provider/vault"
+	"github.com/dirathea/sstart/internal/secrets"
+)
+
+// TestE2E_OpenBao_WithKeys tests the Vault provider (used for OpenBao) with key mappings
+func TestE2E_OpenBao_WithKeys(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup OpenBao container
+	openbaoContainer := SetupOpenBao(ctx, t)
+	defer func() {
+		if err := openbaoContainer.Cleanup(); err != nil {
+			t.Errorf("Failed to terminate OpenBao container: %v", err)
+		}
+	}()
+
+	// Write secret to OpenBao
+	openbaoPath := "myapp/config"
+	openbaoSecretData := map[string]interface{}{
+		"OPENBAO_API_KEY":     "openbao-secret-api-key-67890",
+		"OPENBAO_DB_PASSWORD": "openbao-secret-db-password",
+		"OPENBAO_CONFIG":      "openbao-config-value",
+	}
+	SetupOpenBaoSecret(ctx, t, openbaoContainer, openbaoPath, openbaoSecretData)
+
+	// Create temporary config file
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, ".sstart.yml")
+
+	configYAML := fmt.Sprintf(`
+providers:
+  - kind: vault
+    id: openbao-test
+    path: %s
+    address: %s
+    token: test-token
+    mount: secret
+    keys:
+      OPENBAO_API_KEY: OPENBAO_API_KEY
+      OPENBAO_DB_PASSWORD: OPENBAO_DB_PASSWORD
+      OPENBAO_CONFIG: ==
+`, openbaoPath, openbaoContainer.Address)
+
+	if err := os.WriteFile(configFile, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	// Load config
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Create collector
+	collector := secrets.NewCollector(cfg)
+
+	// Collect secrets from OpenBao provider (using vault provider)
+	collectedSecrets, err := collector.Collect(ctx, nil)
+	if err != nil {
+		t.Fatalf("Failed to collect secrets: %v", err)
+	}
+
+	// Verify OpenBao secrets
+	expectedOpenBaoSecrets := map[string]string{
+		"OPENBAO_API_KEY":     "openbao-secret-api-key-67890",
+		"OPENBAO_DB_PASSWORD": "openbao-secret-db-password",
+		"OPENBAO_CONFIG":      "openbao-config-value", // Same name (==)
+	}
+
+	for key, expectedValue := range expectedOpenBaoSecrets {
+		actualValue, exists := collectedSecrets[key]
+		if !exists {
+			t.Errorf("Expected secret '%s' from OpenBao not found", key)
+			continue
+		}
+		if actualValue != expectedValue {
+			t.Errorf("Secret '%s' from OpenBao: expected '%s', got '%s'", key, expectedValue, actualValue)
+		}
+	}
+
+	// Verify that we have all expected secrets
+	expectedCount := len(expectedOpenBaoSecrets)
+	if len(collectedSecrets) != expectedCount {
+		t.Errorf("Expected %d secrets, got %d. Secrets: %v", expectedCount, len(collectedSecrets), collectedSecrets)
+	}
+
+	t.Logf("Successfully collected %d secrets from OpenBao provider", len(collectedSecrets))
+}
+
+// TestE2E_OpenBao_NoKeys tests the Vault provider (used for OpenBao) without key mappings
+func TestE2E_OpenBao_NoKeys(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup OpenBao container
+	openbaoContainer := SetupOpenBao(ctx, t)
+	defer func() {
+		if err := openbaoContainer.Cleanup(); err != nil {
+			t.Errorf("Failed to terminate OpenBao container: %v", err)
+		}
+	}()
+
+	// Write secret to OpenBao
+	openbaoPath := "myapp/no-keys"
+	openbaoSecretData := map[string]interface{}{
+		"OPENBAO_API_KEY":     "openbao-secret-api-key-67890",
+		"OPENBAO_DB_PASSWORD": "openbao-secret-db-password",
+		"OPENBAO_CONFIG":      "openbao-config-value",
+	}
+	SetupOpenBaoSecret(ctx, t, openbaoContainer, openbaoPath, openbaoSecretData)
+
+	// Create temporary config file
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, ".sstart.yml")
+
+	configYAML := fmt.Sprintf(`
+providers:
+  - kind: vault
+    id: openbao-test
+    path: %s
+    address: %s
+    token: test-token
+    mount: secret
+`, openbaoPath, openbaoContainer.Address)
+
+	if err := os.WriteFile(configFile, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	// Load config
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Create collector
+	collector := secrets.NewCollector(cfg)
+
+	// Collect secrets from OpenBao provider (using vault provider)
+	collectedSecrets, err := collector.Collect(ctx, nil)
+	if err != nil {
+		t.Fatalf("Failed to collect secrets: %v", err)
+	}
+
+	// Verify OpenBao secrets (should use original key names)
+	expectedOpenBaoSecrets := map[string]string{
+		"OPENBAO_API_KEY":     "openbao-secret-api-key-67890",
+		"OPENBAO_DB_PASSWORD": "openbao-secret-db-password",
+		"OPENBAO_CONFIG":      "openbao-config-value",
+	}
+
+	for key, expectedValue := range expectedOpenBaoSecrets {
+		actualValue, exists := collectedSecrets[key]
+		if !exists {
+			t.Errorf("Expected secret '%s' from OpenBao not found", key)
+			continue
+		}
+		if actualValue != expectedValue {
+			t.Errorf("Secret '%s' from OpenBao: expected '%s', got '%s'", key, expectedValue, actualValue)
+		}
+	}
+
+	// Verify that we have all expected secrets
+	expectedCount := len(expectedOpenBaoSecrets)
+	if len(collectedSecrets) != expectedCount {
+		t.Errorf("Expected %d secrets, got %d. Secrets: %v", expectedCount, len(collectedSecrets), collectedSecrets)
+	}
+
+	t.Logf("Successfully collected %d secrets from OpenBao provider without key mappings", len(collectedSecrets))
+}
+


### PR DESCRIPTION
## Summary

This PR adds support for OpenBao alongside HashiCorp Vault. OpenBao is a community-driven, open-source fork of HashiCorp Vault that maintains full API compatibility.

## Changes

- **Added OpenBao container setup** in `tests/end2end/testhelpers.go`:
  - `SetupOpenBao()` function to start an OpenBao container using testcontainers
  - `SetupOpenBaoSecret()` function to write secrets to OpenBao
  - `OpenBaoContainer` type to wrap container, address, and client

- **Added comprehensive end-to-end tests** in `tests/end2end/openbao_test.go`:
  - `TestE2E_OpenBao_WithKeys`: Tests OpenBao with key mappings
  - `TestE2E_OpenBao_NoKeys`: Tests OpenBao without key mappings

- **Updated documentation** in `CONFIGURATION.md`:
  - Updated Vault section title to "HashiCorp Vault / OpenBao"
  - Added OpenBao support documentation explaining API compatibility
  - Included example configuration for OpenBao

## Technical Details

- OpenBao is API-compatible with HashiCorp Vault, so the existing `vault` provider works seamlessly with both systems
- Uses the same HashiCorp Vault API client (`github.com/hashicorp/vault/api`)
- OpenBao container runs in dev mode with `server -dev` command
- All features (KV v1/v2 support, key mappings, etc.) work identically with both Vault and OpenBao

## Testing

All tests pass successfully:
- ✅ `TestE2E_OpenBao_WithKeys` - PASS
- ✅ `TestE2E_OpenBao_NoKeys` - PASS

## Related

Addresses GitHub issue about OpenBao support (as mentioned in the original request).

## Documentation

Updated `CONFIGURATION.md` to document OpenBao support alongside Vault, including:
- Explanation of API compatibility
- Example configuration
- Clarification that the same `vault` provider kind works with both systems