### PR TITLE
fix: linux CGO build, link math.h

### DIFF
--- a/internal/provider/bitwarden/bitwarden_linux.go
+++ b/internal/provider/bitwarden/bitwarden_linux.go
@@ -1,0 +1,8 @@
+//go:build linux
+
+package bitwarden
+
+/*
+#cgo LDFLAGS: -lm
+*/
+import "C"


### PR DESCRIPTION
CGO is needed because of Bitwarden SDK module.
For Linux, it's necessary to link <math.h> explicitly, and the module doesn't do that.

Fixes: https://github.com/dirathea/sstart/issues/28

