### PR TITLE
fix: register azure_keyvault provider so it is reachable at runtime

### DIFF
--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/dirathea/sstart/internal/provider"
+)
+
+// documentedKinds lists every provider kind CONFIGURATION.md advertises.
+// Providers register themselves from init(), so a kind is only reachable from
+// the binary if this package blank-imports it. Keeping the list here catches
+// a provider that is implemented and tested but never wired up.
+var documentedKinds = []string{
+	"1password",
+	"aws_secretsmanager",
+	"azure_keyvault",
+	"bitwarden",
+	"bitwarden_sm",
+	"doppler",
+	"dotenv",
+	"gcloud_secretmanager",
+	"infisical",
+	"template",
+	"vault",
+}
+
+func TestAllDocumentedProvidersAreRegistered(t *testing.T) {
+	registered := make(map[string]bool)
+	for _, kind := range provider.List() {
+		registered[kind] = true
+	}
+
+	for _, kind := range documentedKinds {
+		if !registered[kind] {
+			t.Errorf("provider kind %q is documented but not registered; add a blank import to root.go", kind)
+		}
+		if _, err := provider.New(kind); err != nil {
+			t.Errorf("provider.New(%q) failed: %v", kind, err)
+		}
+	}
+}
+
+func TestNoUndocumentedProvidersAreRegistered(t *testing.T) {
+	documented := make(map[string]bool)
+	for _, kind := range documentedKinds {
+		documented[kind] = true
+	}
+
+	var extra []string
+	for _, kind := range provider.List() {
+		if !documented[kind] {
+			extra = append(extra, kind)
+		}
+	}
+
+	if len(extra) > 0 {
+		sort.Strings(extra)
+		t.Errorf("registered provider kinds missing from CONFIGURATION.md: %v", extra)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	_ "github.com/dirathea/sstart/internal/provider/aws"
+	_ "github.com/dirathea/sstart/internal/provider/azurekeyvault"
 	_ "github.com/dirathea/sstart/internal/provider/bitwarden"
 	_ "github.com/dirathea/sstart/internal/provider/doppler"
 	_ "github.com/dirathea/sstart/internal/provider/dotenv"


### PR DESCRIPTION
## Problem

`kind: azure_keyvault` fails in every released binary:

```
Error: failed to collect secrets: failed to create provider 'az':
unknown provider kind: azure_keyvault
```

The provider itself is fine. It is implemented in `internal/provider/azurekeyvault/`, calls `provider.Register("azure_keyvault", ...)`, has e2e tests, and is documented in `CONFIGURATION.md`. What is missing is the blank import in `internal/cli/root.go`.

Providers register themselves from `init()`, so registration is a side effect of the import graph. A provider package that nobody imports never runs its `init()`, and its kind never enters the registry — with no compile-time error to point at it.

## Why CI did not catch it

The e2e tests import the provider package directly:

```go
// tests/end2end/azure_keyvault_test.go:11
_ "github.com/dirathea/sstart/internal/provider/azurekeyvault"
```

That proves the provider *works*, not that it is *reachable from the binary*. Those are different claims, and only the second one was broken.

## Fix

One blank import in `internal/cli/root.go`, plus a regression test that checks what the e2e tests structurally cannot.

`internal/cli/providers_test.go` asserts the registry against the kinds documented in `CONFIGURATION.md`, in both directions:

- every documented kind is registered and constructible via `provider.New`
- every registered kind is documented

The second direction keeps the docs honest as providers are added. Both live in package `cli`, so they observe the registry after the real import graph has run — which is the only place this bug is visible.

## Verification

Reverting just the one-line import makes the new test fail with a message that names the cause:

```
--- FAIL: TestAllDocumentedProvidersAreRegistered
    providers_test.go:36: provider kind "azure_keyvault" is documented but not
        registered; add a blank import to root.go
    providers_test.go:39: provider.New("azure_keyvault") failed: unknown
        provider kind: azure_keyvault
```

With the import in place, `go test ./internal/cli/` passes, and a rebuilt binary reaches the provider's own validation instead of dying in the registry:

```
Error: ... azure_keyvault provider requires 'secret_name' field in configuration
```

## Note on unrelated failures

`internal/cache`, `internal/provider/vault`, and `internal/provider/gcsm` currently fail on `main`, independently of this change (confirmed by stashing this branch's changes and re-running). The first two fail to compile because their tests reference struct fields that no longer exist. Left alone here to keep this PR to one concern — happy to open a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hmh2p2Bg6kmxxvzpFDW2WL